### PR TITLE
API optimizations

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 node_modules
 build
-test
 benchmarks
 docs
 *.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,7 @@ module.exports = {
   parser: "@typescript-eslint/parser",
   parserOptions: {
     tsconfigRootDir: __dirname,
-    project: ["./tsconfig.json"],
+    project: ["./tsconfig.dev.json"],
     sourceType: "module",
   },
   plugins: ["@typescript-eslint", "import"],

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Static utilities include `Order.MIN_POSITION` and `Order.MAX_POSITION`.
 
 A list of characters, represented as an ordered map with Position keys.
 
-Text is functionally equivalent to a `List<string>` with single-char values, but it uses strings internally and in bulk methods, instead of arrays of single chars. This reduces memory usage and the size of saved states.
+Text is functionally equivalent to `List<string>` with single-char values, but it uses strings internally and in bulk methods, instead of arrays of single chars. This reduces memory usage and the size of saved states.
 
 #### `Outline`
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Position | pos123  posABC  posLMN  posXYZ
 Value    | 'C'     'h'     'a'     't'
 ```
 
-This library provides positions (types `Position`/`LexPosition`) and corresponding list-as-ordered-map data structures (classes `List`/`LexList`/`Outline`). Multiple lists can use the same positions (with the same sort order), including lists on different devices - enabling DIY collaborative lists & text editing.
+This library provides positions (types `Position`/`LexPosition`) and corresponding list-as-ordered-map data structures (classes `List`/`Text`/`Outline`/`LexList`). Multiple lists can use the same positions (with the same sort order), including lists on different devices - enabling DIY collaborative lists & text editing.
 
 ### Example Use Cases
 
@@ -341,6 +341,12 @@ An Order manages metadata (bunches) for any number of Lists, LexLists, and Outli
 
 Static utilities include `Order.MIN_POSITION` and `Order.MAX_POSITION`.
 
+#### `Text`
+
+A list of characters, represented as an ordered map with Position keys.
+
+Text is functionally equivalent to a `List<string>` with single-char values, but it uses strings internally and in bulk methods, instead of arrays of single chars. This reduces memory usage and the size of saved states.
+
 #### `Outline`
 
 An outline for a list of values. It represents an ordered map with Position keys, but unlike List, it only tracks which Positions are present - not their associated values.
@@ -451,3 +457,4 @@ Here are some general performance considerations:
 2. LexPositions and Positions are interchangeable, via the `Order.lex` and `Order.unlex` methods. So you could always start off using the simpler-but-larger LexPositions, then do a data migration to switch to Positions if performance demands it. <!-- TODO: likewise for List/Outline/LexList, via save-conversion methods. -->
 3. The saved states are designed for simplicity, not size. This is why GZIP shrinks them a lot (at the cost of longer save and load times). You can improve on the default performance in various ways: binary encodings, deduplicating [replica IDs](#replica-ids), etc. <!-- TODO: using List.saveOutline and gzipping each separately. --> Before putting too much effort in to this, though, keep in mind that human-written text is small. E.g., the 750 KB CRDT save size above is the size of one image file, even though it represents a 15-page LaTeX paper with 7.5x overhead.
 4. For very large lists, you can choose to call `List.set` on only the Position-value pairs that are currently scrolled into view. This reduces memory and potentially network usage. Likewise, you can choose to deliver only the corresponding BunchMetas to Order.
+5. The Text and Outline classes have smaller memory usage and saved state sizes than List, so prefer those in situations where they are sufficient.

--- a/benchmark_results.md
+++ b/benchmark_results.md
@@ -1,3 +1,7 @@
+
+> list-positions@0.4.0 benchmarks
+> cross-env TS_NODE_PROJECT='./tsconfig.dev.json' node -r ts-node/register --expose-gc benchmarks/main.ts
+
 # Benchmark Results
 Output of
 ```bash
@@ -13,15 +17,15 @@ For perspective on the save sizes: the final text (excluding deleted chars) is 1
 Use `List` and send updates directly over a reliable link (e.g. WebSocket).
 Updates and saved states use JSON encoding, with optional GZIP for saved states.
 
-- Sender time (ms): 634
+- Sender time (ms): 659
 - Avg update size (bytes): 73.5
-- Receiver time (ms): 376
-- Save time (ms): 8
+- Receiver time (ms): 403
+- Save time (ms): 10
 - Save size (bytes): 689516
-- Load time (ms): 18
-- Save time GZIP'd (ms): 114
-- Save size GZIP'd (bytes): 87356
-- Load time GZIP'd (ms): 37
+- Load time (ms): 20
+- Save time GZIP'd (ms): 128
+- Save size GZIP'd (bytes): 87358
+- Load time GZIP'd (ms): 39
 - Mem used (MB): 2.2
 
 ## LexList Direct
@@ -29,33 +33,49 @@ Updates and saved states use JSON encoding, with optional GZIP for saved states.
 Use `LexList` and send updates directly over a reliable link (e.g. WebSocket).
 Updates and saved states use JSON encoding, with optional GZIP for saved states.
 
-- Sender time (ms): 1250
+- Sender time (ms): 1308
 - Avg update size (bytes): 156.6
 - LexPosition length stats: avg = 126.7, percentiles [25, 50, 75, 100] = 100,120,150,258
-- Receiver time (ms): 580
+- Receiver time (ms): 618
 - Save time (ms): 15
 - Save size (bytes): 762273
 - Load time (ms): 28
-- Save time GZIP'd (ms): 90
-- Save size GZIP'd (bytes): 79652
+- Save time GZIP'd (ms): 86
+- Save size GZIP'd (bytes): 79646
 - Load time GZIP'd (ms): 40
-- Mem used (MB): 2.1
+- Mem used (MB): 2.3
 
 ## List Direct w/ Custom Encoding
 
 Use `List` and send updates directly over a reliable link (e.g. WebSocket).
-Updates and saved states use a custom string encoding, with optional GZIP for saved states.
+Updates use a custom string encoding; saved states use JSON with optional GZIP.
 
-- Sender time (ms): 503
+- Sender time (ms): 540
 - Avg update size (bytes): 18.0
-- Receiver time (ms): 366
+- Receiver time (ms): 311
 - Save time (ms): 6
 - Save size (bytes): 689516
-- Load time (ms): 13
-- Save time GZIP'd (ms): 75
-- Save size GZIP'd (bytes): 87358
+- Load time (ms): 11
+- Save time GZIP'd (ms): 77
+- Save size GZIP'd (bytes): 87357
 - Load time GZIP'd (ms): 31
 - Mem used (MB): 2.2
+
+## Text Direct
+
+Use `Text` and send updates directly over a reliable link (e.g. WebSocket).
+Updates and saved states use JSON encoding, with optional GZIP for saved states.
+
+- Sender time (ms): 711
+- Avg update size (bytes): 73.5
+- Receiver time (ms): 511
+- Save time (ms): 7
+- Save size (bytes): 379331
+- Load time (ms): 10
+- Save time GZIP'd (ms): 63
+- Save size GZIP'd (bytes): 69756
+- Load time GZIP'd (ms): 30
+- Mem used (MB): 1.4
 
 ## Outline Direct
 
@@ -63,16 +83,16 @@ Use `Outline` and send updates directly over a reliable link (e.g. WebSocket).
 Updates and saved states use JSON encoding, with optional GZIP for saved states.
 Neither updates nor saved states include values (chars).
 
-- Sender time (ms): 656
+- Sender time (ms): 668
 - Avg update size (bytes): 65.0
-- Receiver time (ms): 411
+- Receiver time (ms): 379
 - Save time (ms): 5
 - Save size (bytes): 267915
 - Load time (ms): 9
-- Save time GZIP'd (ms): 48
-- Save size GZIP'd (bytes): 36970
-- Load time GZIP'd (ms): 17
-- Mem used (MB): 1.5
+- Save time GZIP'd (ms): 51
+- Save size GZIP'd (bytes): 36972
+- Load time GZIP'd (ms): 25
+- Mem used (MB): 1.3
 
 ## PositionCRDT
 
@@ -80,16 +100,16 @@ Use a hybrid op-based/state-based CRDT on top of List+Outline.
 This variant uses Positions in messages, manually managing BunchMetas.
 Updates and saved states use JSON encoding, with optional GZIP for saved states.
 
-- Sender time (ms): 676
+- Sender time (ms): 783
 - Avg update size (bytes): 73.5
-- Receiver time (ms): 509
-- Save time (ms): 10
+- Receiver time (ms): 530
+- Save time (ms): 14
 - Save size (bytes): 752573
-- Load time (ms): 20
-- Save time GZIP'd (ms): 81
-- Save size GZIP'd (bytes): 100020
+- Load time (ms): 18
+- Save time GZIP'd (ms): 82
+- Save size GZIP'd (bytes): 100013
 - Load time GZIP'd (ms): 37
-- Mem used (MB): 2.7
+- Mem used (MB): 2.6
 
 ## LexPositionCRDT
 
@@ -97,13 +117,13 @@ Use a hybrid op-based/state-based CRDT on top of List+Outline.
 This variant uses LexPositions in messages instead of manually managing BunchMetas.
 Updates and saved states use JSON encoding, with optional GZIP for saved states.
 
-- Sender time (ms): 1188
+- Sender time (ms): 1365
 - Avg update size (bytes): 156.6
-- Receiver time (ms): 600
+- Receiver time (ms): 614
 - Save time (ms): 8
 - Save size (bytes): 752573
-- Load time (ms): 15
-- Save time GZIP'd (ms): 80
-- Save size GZIP'd (bytes): 100017
-- Load time GZIP'd (ms): 36
-- Mem used (MB): 2.8
+- Load time (ms): 16
+- Save time GZIP'd (ms): 82
+- Save size GZIP'd (bytes): 100014
+- Load time GZIP'd (ms): 47
+- Mem used (MB): 2.7

--- a/benchmark_results.md
+++ b/benchmark_results.md
@@ -1,7 +1,3 @@
-
-> list-positions@0.4.0 benchmarks
-> cross-env TS_NODE_PROJECT='./tsconfig.dev.json' node -r ts-node/register --expose-gc benchmarks/main.ts
-
 # Benchmark Results
 Output of
 ```bash

--- a/benchmarks/main.ts
+++ b/benchmarks/main.ts
@@ -5,6 +5,7 @@ import { lexListDirect } from "./lex_list_direct";
 import { listCustomEncoding } from "./list_custom_encoding";
 import { listDirect } from "./list_direct";
 import { outlineDirect } from "./outline_direct";
+import { textDirect } from "./text_direct";
 
 (async function () {
   console.log("# Benchmark Results");
@@ -21,6 +22,7 @@ import { outlineDirect } from "./outline_direct";
   await listDirect();
   await lexListDirect();
   await listCustomEncoding();
+  await textDirect();
   await outlineDirect();
   await crdt(PositionCRDT);
   await crdt(LexPositionCRDT);

--- a/benchmarks/text_direct.ts
+++ b/benchmarks/text_direct.ts
@@ -1,0 +1,178 @@
+import { assert } from "chai";
+import pako from "pako";
+import {
+  BunchMeta,
+  OrderSavedState,
+  Position,
+  Text,
+  TextSavedState,
+} from "../src";
+import realTextTraceEdits from "./internal/real_text_trace_edits.json";
+import { avg, getMemUsed, sleep } from "./internal/util";
+
+const { edits, finalText } = realTextTraceEdits as unknown as {
+  finalText: string;
+  edits: Array<[number, number, string | undefined]>;
+};
+
+type Update =
+  | {
+      type: "set";
+      pos: Position;
+      value: string;
+      meta?: BunchMeta;
+    }
+  | { type: "delete"; pos: Position };
+
+type SavedState = {
+  order: OrderSavedState;
+  text: TextSavedState;
+};
+
+export async function textDirect() {
+  console.log("\n## Text Direct\n");
+  console.log(
+    "Use `Text` and send updates directly over a reliable link (e.g. WebSocket)."
+  );
+  console.log(
+    "Updates and saved states use JSON encoding, with optional GZIP for saved states.\n"
+  );
+
+  // Perform the whole trace, sending all updates.
+  const updates: string[] = [];
+  let startTime = process.hrtime.bigint();
+  const sender = new Text();
+  for (const edit of edits) {
+    let updateObj: Update;
+    if (edit[2] !== undefined) {
+      const [pos, createdBunch] = sender.insertAt(edit[0], edit[2]);
+      updateObj = { type: "set", pos, value: edit[2] };
+      if (createdBunch !== null) updateObj.meta = createdBunch;
+    } else {
+      const pos = sender.positionAt(edit[0]);
+      sender.delete(pos);
+      updateObj = { type: "delete", pos };
+    }
+
+    updates.push(JSON.stringify(updateObj));
+  }
+
+  console.log(
+    "- Sender time (ms):",
+    Math.round(
+      new Number(process.hrtime.bigint() - startTime).valueOf() / 1000000
+    )
+  );
+  console.log(
+    "- Avg update size (bytes):",
+    avg(updates.map((message) => message.length)).toFixed(1)
+  );
+  assert.strictEqual(sender.toString(), finalText);
+
+  // Receive all updates.
+  startTime = process.hrtime.bigint();
+  const receiver = new Text();
+  for (const update of updates) {
+    const updateObj: Update = JSON.parse(update);
+    if (updateObj.type === "set") {
+      if (updateObj.meta) receiver.order.receive([updateObj.meta]);
+      receiver.set(updateObj.pos, updateObj.value);
+      // To simulate events, also compute the inserted index.
+      void receiver.indexOfPosition(updateObj.pos);
+    } else {
+      // type "delete"
+      if (receiver.has(updateObj.pos)) {
+        // To simulate events, also compute the inserted index.
+        void receiver.indexOfPosition(updateObj.pos);
+        receiver.delete(updateObj.pos); // Also okay to call outside of the "has" guard.
+      }
+    }
+  }
+
+  console.log(
+    "- Receiver time (ms):",
+    Math.round(
+      new Number(process.hrtime.bigint() - startTime).valueOf() / 1000000
+    )
+  );
+  assert.strictEqual(receiver.toString(), finalText);
+
+  const savedState = (await saveLoad(receiver, false)) as string;
+  await saveLoad(receiver, true);
+
+  await memory(savedState);
+}
+
+async function saveLoad(
+  saver: Text,
+  gzip: boolean
+): Promise<string | Uint8Array> {
+  // Save.
+  let startTime = process.hrtime.bigint();
+  const savedStateObj: SavedState = {
+    order: saver.order.save(),
+    text: saver.save(),
+  };
+  const savedState = gzip
+    ? pako.gzip(JSON.stringify(savedStateObj))
+    : JSON.stringify(savedStateObj);
+
+  console.log(
+    `- Save time ${gzip ? "GZIP'd " : ""}(ms):`,
+    Math.round(
+      new Number(process.hrtime.bigint() - startTime).valueOf() / 1000000
+    )
+  );
+  console.log(
+    `- Save size ${gzip ? "GZIP'd " : ""}(bytes):`,
+    savedState.length
+  );
+
+  // Load the saved state.
+  startTime = process.hrtime.bigint();
+  const loader = new Text();
+  const toLoadStr = gzip
+    ? pako.ungzip(savedState as Uint8Array, { to: "string" })
+    : (savedState as string);
+  const toLoadObj: SavedState = JSON.parse(toLoadStr);
+  // Important to load Order first.
+  loader.order.load(toLoadObj.order);
+  loader.load(toLoadObj.text);
+
+  console.log(
+    `- Load time ${gzip ? "GZIP'd " : ""}(ms):`,
+    Math.round(
+      new Number(process.hrtime.bigint() - startTime).valueOf() / 1000000
+    )
+  );
+
+  return savedState;
+}
+
+async function memory(savedState: string) {
+  // Measure memory usage of loading the saved state.
+
+  // Pause (& separate function)seems to make GC more consistent -
+  // less likely to get negative diffs.
+  await sleep(1000);
+  const startMem = getMemUsed();
+
+  const loader = new Text();
+  // Keep the parsed saved state in a separate scope so it can be GC'd
+  // before we measure memory.
+  (function () {
+    const savedStateObj: SavedState = JSON.parse(savedState);
+    // Important to load Order first.
+    loader.order.load(savedStateObj.order);
+    loader.load(savedStateObj.text);
+  })();
+
+  console.log(
+    "- Mem used (MB):",
+    ((getMemUsed() - startMem) / 1000000).toFixed(1)
+  );
+
+  // Keep stuff in scope so we don't accidentally subtract its memory usage.
+  void loader;
+  void savedState;
+}

--- a/internals.md
+++ b/internals.md
@@ -41,7 +41,7 @@ We could choose to represent the tree literally, with one object per node and a 
 
 Instead, Order only stores an object per bunch node, of type [BunchNode](./README.md#interface-bunchnode); offset nodes are implied. Each BunchNode stores a pointer to the bunch node's "parent bunch node" (actually its grandparent), its offset (which tells you the actual parent node), and pointers to its "children bunch nodes" in tree order (actually its grandchildren). This info is sufficient to compare Positions and traverse the tree.
 
-List, Outline, and LexList likewise avoid storing an object per Position/value. Instead, they store a map (BunchNode -> sparse array), where the sparse array represents the sub-map (innerIndex -> value) corresponding to that bunch. The sparse arrays use a run-length-encoded format that you can read about in the `...SavedState` doc headers.
+List, Text, Outline, and LexList likewise avoid storing an object per Position/value. Instead, they store a map (BunchNode -> sparse array), where the sparse array represents the sub-map (innerIndex -> value) corresponding to that bunch. The sparse arrays use a run-length-encoded format that you can read about in the `...SavedState` doc headers.
 
 ## LexPositions
 

--- a/internals.md
+++ b/internals.md
@@ -41,7 +41,7 @@ We could choose to represent the tree literally, with one object per node and a 
 
 Instead, Order only stores an object per bunch node, of type [BunchNode](./README.md#interface-bunchnode); offset nodes are implied. Each BunchNode stores a pointer to the bunch node's "parent bunch node" (actually its grandparent), its offset (which tells you the actual parent node), and pointers to its "children bunch nodes" in tree order (actually its grandchildren). This info is sufficient to compare Positions and traverse the tree.
 
-List, Text, Outline, and LexList likewise avoid storing an object per Position/value. Instead, they store a map (BunchNode -> sparse array), where the sparse array represents the sub-map (innerIndex -> value) corresponding to that bunch. The sparse arrays use a run-length-encoded format that you can read about in the `...SavedState` doc headers.
+List, Text, Outline, and LexList likewise avoid storing an object per Position/value. Instead, they store a map (BunchNode -> sparse array), where the sparse array represents the sub-map (innerIndex -> value) corresponding to that bunch. The sparse arrays come from the [sparse-array-rled](https://github.com/mweidner037/sparse-array-rled#readme) package, which uses run-length encoded deletions, both internally and in saved states.
 
 ## LexPositions
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
 export * from "./bunch";
 export * from "./bunch_ids";
 export * from "./lex_list";
-export { LexUtils } from "./lex_utils"; // Other exports are for testsonly.
+export * from "./lex_utils";
 export * from "./list";
 export * from "./order";
 export * from "./outline";
 export * from "./position";
+export * from "./text";

--- a/src/internal/item_list.ts
+++ b/src/internal/item_list.ts
@@ -567,6 +567,19 @@ export class ItemList<I, S extends SparseItems<I>> {
     }
   }
 
+  /**
+   * Returns an iterator for all dependencies for this list.
+   *
+   * These are all BunchNodes that have nontrivial values plus their ancestors,
+   * excluding the root.
+   */
+  *dependentNodes(): IterableIterator<BunchNode> {
+    // OPT: Use state.keys() directly, if we can exclude the root somehow.
+    for (const node of this.state.keys()) {
+      if (node !== this.order.rootNode) yield node;
+    }
+  }
+
   // ----------
   // Save & Load
   // ----------

--- a/src/internal/item_list.ts
+++ b/src/internal/item_list.ts
@@ -465,15 +465,23 @@ export class ItemList<I, S extends SparseItems<I>> {
    * Returns an iterator of [startPos, item] pairs for every
    * contiguous item in the list, in list order.
    *
-   * Args as in Array.slice.
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   *items(
-    start?: number,
-    end?: number
+    start = 0,
+    end = this.length
   ): IterableIterator<[startPos: Position, item: I]> {
-    const range = this.normalizeSliceRange(start, end);
-    if (range === null) return;
-    [start, end] = range;
+    if (start < 0 || end > this.length || start > end) {
+      throw new Error(
+        `Invalid range: [${start}, ${end}) (length = ${this.length})`
+      );
+    }
+    // Note: start = end = this.length is okay.
+    // (used by normalizeSliceRange).
+    if (start === end) return;
 
     let index = 0;
     // Defined because the range is nontrivial, hence root's total != 0.
@@ -557,28 +565,6 @@ export class ItemList<I, S extends SparseItems<I>> {
         }
       }
     }
-  }
-
-  /**
-   * Normalizes the range so that start < end and they are both in bounds
-   * (possibly end=length), following Array.slice.
-   * If the range is empty, returns null.
-   */
-  private normalizeSliceRange(
-    start?: number,
-    end?: number
-  ): [start: number, end: number] | null {
-    const len = this.length;
-    if (start === undefined || start < -len) start = 0;
-    else if (start < 0) start += len;
-    else if (start >= len) return null;
-
-    if (end === undefined || end >= len) end = len;
-    else if (end < -len) end = 0;
-    else if (end < 0) end += len;
-
-    if (end <= start) return null;
-    return [start, end];
   }
 
   // ----------

--- a/src/internal/item_list.ts
+++ b/src/internal/item_list.ts
@@ -567,19 +567,6 @@ export class ItemList<I, S extends SparseItems<I>> {
     }
   }
 
-  /**
-   * Returns an iterator for all dependencies for this list.
-   *
-   * These are all BunchNodes that have nontrivial values plus their ancestors,
-   * excluding the root.
-   */
-  *dependentNodes(): IterableIterator<BunchNode> {
-    // OPT: Use state.keys() directly, if we can exclude the root somehow.
-    for (const node of this.state.keys()) {
-      if (node !== this.order.rootNode) yield node;
-    }
-  }
-
   // ----------
   // Save & Load
   // ----------

--- a/src/internal/item_list.ts
+++ b/src/internal/item_list.ts
@@ -462,7 +462,7 @@ export class ItemList<I, S extends SparseItems<I>> {
   // ----------
 
   /**
-   * Returns an iterator of [startPos, item] tuples for every
+   * Returns an iterator of [startPos, item] pairs for every
    * contiguous item in the list, in list order.
    *
    * Args as in Array.slice.

--- a/src/internal/item_list.ts
+++ b/src/internal/item_list.ts
@@ -628,7 +628,7 @@ export class ItemList<I, S extends SparseItems<I>> {
       const node = this.order.getNode(bunchID);
       if (node === undefined) {
         throw new Error(
-          `List/Outline savedState references missing bunchID: "${bunchID}". You must call Order.receive before referencing a bunch.`
+          `List/Text/Outline savedState references missing bunchID: "${bunchID}". You must call Order.receive before referencing a bunch.`
         );
       }
 

--- a/src/internal/util.ts
+++ b/src/internal/util.ts
@@ -1,0 +1,20 @@
+/**
+ * Normalizes the range so that start < end and they are both in bounds
+ * (possibly start=end=length), following Array.slice.
+ */
+export function normalizeSliceRange(
+  length: number,
+  start?: number,
+  end?: number
+): [start: number, end: number] {
+  if (start === undefined || start < -length) start = 0;
+  else if (start < 0) start += length;
+  else if (start >= length) return [length, length];
+
+  if (end === undefined || end >= length) end = length;
+  else if (end < -length) end = 0;
+  else if (end < 0) end += length;
+
+  if (end <= start) return [start, start];
+  return [start, end];
+}

--- a/src/lex_list.ts
+++ b/src/lex_list.ts
@@ -302,7 +302,10 @@ export class LexList<T> {
   /**
    * Returns an iterator for values in the list, in list order.
    *
-   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   values(start?: number, end?: number): IterableIterator<T> {
     return this.list.values(start, end);
@@ -320,7 +323,10 @@ export class LexList<T> {
   /**
    * Returns an iterator for present positions, in list order.
    *
-   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   *positions(start?: number, end?: number): IterableIterator<LexPosition> {
     for (const pos of this.list.positions(start, end))
@@ -330,7 +336,10 @@ export class LexList<T> {
   /**
    * Returns an iterator of [lexPos, value] tuples in the list, in list order. These are its entries as an ordered map.
    *
-   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   *entries(
     start?: number,

--- a/src/lex_list.ts
+++ b/src/lex_list.ts
@@ -43,7 +43,7 @@ export class LexList<T> {
   /**
    * The Order that manages this list's Positions and their metadata.
    *
-   * Unlike with List and Outline, you do not need to [Manage Metadata](https://github.com/mweidner037/list-positions#managing-metadata)
+   * Unlike with List/Text/Outline, you do not need to [Manage Metadata](https://github.com/mweidner037/list-positions#managing-metadata)
    * when using LexList. However, you can still access the Order
    * to convert between LexPositions and Positions (using `Order.lex` / `Order.unlex`)
    * or to share the Order with other data structures.
@@ -272,7 +272,7 @@ export class LexList<T> {
    * Returns the cursor at `index` within the list, i.e., between the positions at `index - 1` and `index`.
    * See [Cursors](https://github.com/mweidner037/list-positions#cursors).
    *
-   * Invert with indexOfCursor, possibly on a different List/Outline/LexList or a different device.
+   * Invert with indexOfCursor, possibly on a different List/Text/Outline/LexList or a different device.
    */
   cursorAt(index: number): LexPosition {
     return index === 0 ? Order.MIN_LEX_POSITION : this.positionAt(index - 1);

--- a/src/lex_list.ts
+++ b/src/lex_list.ts
@@ -334,7 +334,7 @@ export class LexList<T> {
   }
 
   /**
-   * Returns an iterator of [lexPos, value] tuples in the list, in list order. These are its entries as an ordered map.
+   * Returns an iterator for [lexPos, value] pairs in the list, in list order. These are its entries as an ordered map.
    *
    * Optionally, you may specify a range of indices `[start, end)` instead of
    * iterating the entire list.

--- a/src/lex_list.ts
+++ b/src/lex_list.ts
@@ -64,7 +64,7 @@ export class LexList<T> {
    * Multiple Lists/Outlines/Texts/LexLists can share an Order; they then automatically
    * share metadata. If not provided, a `new Order()` is used.
    *
-   * @see LexList.from To construct a LexList from an initial set of entries.
+   * @see LexList.fromEntries To construct a LexList from an initial set of entries.
    */
   constructor(order?: Order);
   /**
@@ -87,7 +87,7 @@ export class LexList<T> {
    * Unlike with List.from, you do not need to deliver metadata to this
    * Order beforehand.
    */
-  static from<T>(
+  static fromEntries<T>(
     entries: Iterable<[lexPos: LexPosition, value: T]>,
     order?: Order
   ): LexList<T> {

--- a/src/lex_list.ts
+++ b/src/lex_list.ts
@@ -61,7 +61,7 @@ export class LexList<T> {
    * Constructs a LexList, initially empty.
    *
    * @param order The Order to use for `this.order`.
-   * Multiple Lists/Outlines/LexLists can share an Order; they then automatically
+   * Multiple Lists/Outlines/Texts/LexLists can share an Order; they then automatically
    * share metadata. If not provided, a `new Order()` is used.
    *
    * @see LexList.from To construct a LexList from an initial set of entries.

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,5 +1,5 @@
 import { SparseArray } from "sparse-array-rled";
-import { BunchMeta, BunchNode } from "./bunch";
+import { BunchMeta } from "./bunch";
 import { ItemList, SparseItemsFactory } from "./internal/item_list";
 import { normalizeSliceRange } from "./internal/util";
 import { Order } from "./order";
@@ -458,16 +458,6 @@ export class List<T> {
     end?: number
   ): IterableIterator<[startPos: Position, values: T[]]> {
     return this.itemList.items(start, end);
-  }
-
-  /**
-   * Returns an iterator for all dependencies for this list.
-   *
-   * These are all BunchNodes that have nontrivial values plus their ancestors,
-   * excluding the root.
-   */
-  dependentNodes(): IterableIterator<BunchNode> {
-    return this.itemList.dependentNodes();
   }
 
   // ----------

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,5 +1,5 @@
 import { SparseArray } from "sparse-array-rled";
-import { BunchMeta } from "./bunch";
+import { BunchMeta, BunchNode } from "./bunch";
 import { ItemList, SparseItemsFactory } from "./internal/item_list";
 import { normalizeSliceRange } from "./internal/util";
 import { Order } from "./order";
@@ -416,7 +416,7 @@ export class List<T> {
   }
 
   /**
-   * Returns an iterator of [pos, value] tuples in the list, in list order. These are its entries as an ordered map.
+   * Returns an iterator for [pos, value] pairs in the list, in list order. These are its entries as an ordered map.
    *
    * Optionally, you may specify a range of indices `[start, end)` instead of
    * iterating the entire list.
@@ -438,7 +438,7 @@ export class List<T> {
   }
 
   /**
-   * Returns an iterator of items in list order.
+   * Returns an iterator for items in list order.
    *
    * Each *item* is a series of entries that have contiguous positions
    * from the same [bunch](https://github.com/mweidner037/list-positions#bunches).
@@ -458,6 +458,16 @@ export class List<T> {
     end?: number
   ): IterableIterator<[startPos: Position, values: T[]]> {
     return this.itemList.items(start, end);
+  }
+
+  /**
+   * Returns an iterator for all dependencies for this list.
+   *
+   * These are all BunchNodes that have nontrivial values plus their ancestors,
+   * excluding the root.
+   */
+  dependentNodes(): IterableIterator<BunchNode> {
+    return this.itemList.dependentNodes();
   }
 
   // ----------

--- a/src/list.ts
+++ b/src/list.ts
@@ -350,7 +350,7 @@ export class List<T> {
    * Returns the cursor at `index` within the list, i.e., between the positions at `index - 1` and `index`.
    * See [Cursors](https://github.com/mweidner037/list-positions#cursors).
    *
-   * Invert with indexOfCursor, possibly on a different List/Outline/LexList or a different device.
+   * Invert with indexOfCursor, possibly on a different List/Text/Outline/LexList or a different device.
    */
   cursorAt(index: number): Position {
     return index === 0 ? Order.MIN_POSITION : this.positionAt(index - 1);

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,6 +1,7 @@
 import { SparseArray } from "sparse-array-rled";
 import { BunchMeta } from "./bunch";
 import { ItemList, SparseItemsFactory } from "./internal/item_list";
+import { normalizeSliceRange } from "./internal/util";
 import { Order } from "./order";
 import { Position } from "./position";
 
@@ -379,7 +380,10 @@ export class List<T> {
   /**
    * Returns an iterator for values in the list, in list order.
    *
-   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   *values(start?: number, end?: number): IterableIterator<T> {
     for (const [, item] of this.itemList.items(start, end)) yield* item;
@@ -391,13 +395,21 @@ export class List<T> {
    * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
    */
   slice(start?: number, end?: number): T[] {
-    return [...this.values(start, end)];
+    [start, end] = normalizeSliceRange(this.length, start, end);
+    const ans: T[] = [];
+    for (const [, values] of this.itemList.items(start, end)) {
+      ans.push(...values);
+    }
+    return ans;
   }
 
   /**
    * Returns an iterator for present positions, in list order.
    *
-   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   *positions(start?: number, end?: number): IterableIterator<Position> {
     for (const [pos] of this.entries(start, end)) yield pos;
@@ -406,7 +418,10 @@ export class List<T> {
   /**
    * Returns an iterator of [pos, value] tuples in the list, in list order. These are its entries as an ordered map.
    *
-   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   *entries(
     start?: number,
@@ -433,7 +448,10 @@ export class List<T> {
    * You can use this method as an optimized version of other iterators, or as
    * an alternative in-order save format (see List.fromItems).
    *
-   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   items(
     start?: number,

--- a/src/list.ts
+++ b/src/list.ts
@@ -69,7 +69,7 @@ export class List<T> {
    * Constructs a List, initially empty.
    *
    * @param order The Order to use for `this.order`.
-   * Multiple Lists/Outlines/LexLists can share an Order; they then automatically
+   * Multiple Lists/Outlines/Texts/LexLists can share an Order; they then automatically
    * share metadata. If not provided, a `new Order()` is used.
    *
    * @see List.fromEntries To construct a List from an initial set of entries.

--- a/src/order.ts
+++ b/src/order.ts
@@ -614,7 +614,7 @@ export class Order {
   // ----------
 
   /**
-   * Returns an iterator of this Order's BunchNodes.
+   * Returns an iterator for this Order's BunchNodes.
    *
    * The root (`this.rootNode`) is always visited first, followed by the remaining
    * nodes in no particular order.
@@ -624,7 +624,7 @@ export class Order {
   }
 
   /**
-   * Returns an iterator of this Order's BunchMetas,
+   * Returns an iterator for this Order's BunchMetas,
    * in no particular order.
    *
    * This is the same as calling `node.meta()` on each output of `this.nodes()`

--- a/src/order.ts
+++ b/src/order.ts
@@ -154,7 +154,7 @@ export class Order {
   /**
    * Constructs an Order.
    *
-   * Any data structures (List, Outline, LexList) that share this Order
+   * Any data structures (List, Text, Outline, LexList) that share this Order
    * automatically share the same total order on Positions.
    * To share total orders between Order instances (possibly on different devices),
    * you will need to
@@ -226,7 +226,7 @@ export class Order {
    * for Positions within this Order.
    *
    * You may use this method to work with Positions in a list-as-ordered-map
-   * data structure other than our built-in classes (List, Outline, LexList), e.g.,
+   * data structure other than our built-in classes (List, Text, Outline, LexList), e.g.,
    * [functional-red-black-tree](https://www.npmjs.com/package/functional-red-black-tree)
    * or `Array.sort`.
    *
@@ -284,7 +284,7 @@ export class Order {
   /**
    * Receives the given BunchMetas.
    *
-   * Before using a Position with this Order or an associated List or Outline,
+   * Before using a Position with this Order or an associated List/Text/Outline,
    * you must deliver its bunch's BunchMeta to this method.
    * See [Managing Metadata](https://github.com/mweidner037/list-positions#managing-metadata).
    *

--- a/src/outline.ts
+++ b/src/outline.ts
@@ -334,7 +334,10 @@ export class Outline {
   /**
    * Returns an iterator for present positions, in list order.
    *
-   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   *positions(start?: number, end?: number): IterableIterator<Position> {
     for (const [
@@ -358,7 +361,10 @@ export class Outline {
    * You can use this method as an optimized version of other iterators, or as
    * an alternative in-order save format (see Outline.fromItems).
    *
-   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   items(
     start?: number,

--- a/src/outline.ts
+++ b/src/outline.ts
@@ -67,7 +67,7 @@ export class Outline {
    * Multiple Lists/Outlines/LexLists can share an Order; they then automatically
    * share metadata. If not provided, a `new Order()` is used.
    *
-   * @see Outline.from To construct an Outline from an initial set of Positions.
+   * @see Outline.fromPositions To construct an Outline from an initial set of Positions.
    */
   constructor(order?: Order) {
     this.order = order ?? new Order();
@@ -80,10 +80,28 @@ export class Outline {
    * Like when loading a saved state, you must deliver all of the Positions'
    * dependent metadata to `order` before calling this method.
    */
-  static from(positions: Iterable<Position>, order: Order): Outline {
+  static fromPositions(positions: Iterable<Position>, order: Order): Outline {
     const outline = new Outline(order);
     for (const pos of positions) {
       outline.add(pos);
+    }
+    return outline;
+  }
+
+  /**
+   * Returns a new Outline using the given Order and with the given
+   * items (as defined by Outline.items).
+   *
+   * Like when loading a saved state, you must deliver all of the Positions'
+   * dependent metadata to `order` before calling this method.
+   */
+  static fromItems(
+    items: Iterable<[startPos: Position, count: number]>,
+    order: Order
+  ): Outline {
+    const outline = new Outline(order);
+    for (const [startPos, count] of items) {
+      outline.add(startPos, count);
     }
     return outline;
   }
@@ -327,6 +345,26 @@ export class Outline {
         yield { bunchID, innerIndex: startInnerIndex + i };
       }
     }
+  }
+
+  /**
+   * Returns an iterator of items in list order.
+   *
+   * Each *item* is a series of entries that have contiguous positions
+   * from the same [bunch](https://github.com/mweidner037/list-positions#bunches).
+   * Specifically, for an item [startPos, count], the positions start at `startPos`
+   * and have the same `bunchID` but increasing `innerIndex`.
+   *
+   * You can use this method as an optimized version of other iterators, or as
+   * an alternative in-order save format (see Outline.fromItems).
+   *
+   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   */
+  items(
+    start?: number,
+    end?: number
+  ): IterableIterator<[startPos: Position, count: number]> {
+    return this.itemList.items(start, end);
   }
 
   // ----------

--- a/src/outline.ts
+++ b/src/outline.ts
@@ -1,5 +1,5 @@
 import { SparseIndices } from "sparse-array-rled";
-import { BunchMeta, BunchNode } from "./bunch";
+import { BunchMeta } from "./bunch";
 import { ItemList, SparseItemsFactory } from "./internal/item_list";
 import { Order } from "./order";
 import { Position } from "./position";
@@ -371,16 +371,6 @@ export class Outline {
     end?: number
   ): IterableIterator<[startPos: Position, count: number]> {
     return this.itemList.items(start, end);
-  }
-
-  /**
-   * Returns an iterator for all dependencies for this list.
-   *
-   * These are all BunchNodes that have nontrivial values plus their ancestors,
-   * excluding the root.
-   */
-  dependentNodes(): IterableIterator<BunchNode> {
-    return this.itemList.dependentNodes();
   }
 
   // ----------

--- a/src/outline.ts
+++ b/src/outline.ts
@@ -1,5 +1,5 @@
 import { SparseIndices } from "sparse-array-rled";
-import { BunchMeta } from "./bunch";
+import { BunchMeta, BunchNode } from "./bunch";
 import { ItemList, SparseItemsFactory } from "./internal/item_list";
 import { Order } from "./order";
 import { Position } from "./position";
@@ -351,7 +351,7 @@ export class Outline {
   }
 
   /**
-   * Returns an iterator of items in list order.
+   * Returns an iterator for items in list order.
    *
    * Each *item* is a series of entries that have contiguous positions
    * from the same [bunch](https://github.com/mweidner037/list-positions#bunches).
@@ -371,6 +371,16 @@ export class Outline {
     end?: number
   ): IterableIterator<[startPos: Position, count: number]> {
     return this.itemList.items(start, end);
+  }
+
+  /**
+   * Returns an iterator for all dependencies for this list.
+   *
+   * These are all BunchNodes that have nontrivial values plus their ancestors,
+   * excluding the root.
+   */
+  dependentNodes(): IterableIterator<BunchNode> {
+    return this.itemList.dependentNodes();
   }
 
   // ----------

--- a/src/position.ts
+++ b/src/position.ts
@@ -4,7 +4,7 @@
  * Positions let you treat a list as an ordered map `(position -> value)`,
  * where a value's *position* doesn't change over time - unlike an array index.
  *
- * Type Position is used with the library's List and Outline data structures.
+ * Type Position is used with the library's List, Text, and Outline data structures.
  * You can also work with Positions independent of a specific list using an Order.
  * See the [readme](https://github.com/mweidner037/list-positions#list-position-and-order)
  * for details.
@@ -39,7 +39,7 @@ export type Position = {
  *
  * See also:
  * - Position: An alternative representation of positions that is used with
- * List, Outline, and Order and has less metadata overhead.
+ * List, Text, Outline, and Order and has less metadata overhead.
  * - LexUtils: Utilities for manipulating LexPositions.
  */
 export type LexPosition = string;

--- a/src/text.ts
+++ b/src/text.ts
@@ -351,7 +351,7 @@ export class Text {
    * Returns the cursor at `index` within the list, i.e., between the positions at `index - 1` and `index`.
    * See [Cursors](https://github.com/mweidner037/list-positions#cursors).
    *
-   * Invert with indexOfCursor, possibly on a different List/Outline/LexList or a different device.
+   * Invert with indexOfCursor, possibly on a different List/Text/Outline/LexList or a different device.
    */
   cursorAt(index: number): Position {
     return index === 0 ? Order.MIN_POSITION : this.positionAt(index - 1);

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,109 +1,121 @@
-import { SparseIndices } from "sparse-array-rled";
+import { SparseString } from "sparse-array-rled";
 import { BunchMeta, BunchNode } from "./bunch";
 import { ItemList, SparseItemsFactory } from "./internal/item_list";
+import { normalizeSliceRange } from "./internal/util";
 import { Order } from "./order";
 import { Position } from "./position";
 
-const sparseIndicesFactory: SparseItemsFactory<number, SparseIndices> = {
+const sparseStringFactory: SparseItemsFactory<string, SparseString> = {
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  new: SparseIndices.new,
+  new: SparseString.new,
   // eslint-disable-next-line @typescript-eslint/unbound-method
-  deserialize: SparseIndices.deserialize,
+  deserialize: SparseString.deserialize,
   length(item) {
-    return item;
+    return item.length;
   },
-  slice(_item, start, end) {
-    return end - start;
+  slice(item, start, end) {
+    return item.slice(start, end);
   },
 } as const;
 
+function checkChar(char: string): void {
+  if (char.length !== 1) {
+    throw new Error(`Values must be single chars, not "${char}"`);
+  }
+}
+
 /**
- * A JSON-serializable saved state for an Outline.
+ * A JSON-serializable saved state for a `Text`.
  *
- * See Outline.save and Outline.load.
+ * See Text.save and Text.load.
  *
  * ### Format
  *
- * For advanced usage, you may read and write OutlineSavedStates directly.
+ * For advanced usage, you may read and write TextSavedStates directly.
  *
  * The format is: For each [bunch](https://github.com/mweidner037/list-positions#bunches)
- * with Positions present in the Outline, map the bunch's ID to a sparse array
+ * with Positions present in the Text, map the bunch's ID to a sparse string
  * representing the map
  * ```
- * innerIndex -> (true if Position { bunchID, innerIndex } is present).
+ * innerIndex -> (char at Position { bunchID, innerIndex }).
  * ```
  * bunchID keys are in no particular order.
  *
- * Each sparse array of type `number[]` alternates between "runs" of present and deleted
- * values. Each even index is a count of present values; each odd
+ * Each sparse string of type `(string | number)[]` alternates between "runs" of present and deleted
+ * values. Each even index is a string of concatenated present chars; each odd
  * index is a count of deleted values.
- * E.g. `[2, 3, 1]` means `[true, true, null, null, null, true]`.
+ * E.g. `["ab", 3, "c"]` means `["a", "b", null, null, null, "c"]`.
  */
-export type OutlineSavedState = {
-  [bunchID: string]: number[];
+export type TextSavedState = {
+  [bunchID: string]: (string | number)[];
 };
 
 /**
- * An outline for a list of values. It represents an ordered set of Positions. Unlike List,
- * it only tracks which Positions are present - not their associated values.
+ * A list of characters, represented as an ordered map with Position keys.
  *
- * See [Outline](https://github.com/mweidner037/list-positions#outline) in the readme.
+ * See [List, Position, and Order](https://github.com/mweidner037/list-positions#list-position-and-order) in the readme.
  *
- * Outline's API is a hybrid between `Array<Position>` and `Set<Position>`.
- * Use `insertAt` or `insert` to insert new Positions into the list in the style of `Array.splice`.
+ * Text is functionally equivalent to a `List<string>` with single-char values,
+ * but it uses strings internally and in bulk methods, instead of arrays
+ * of single chars. This reduces memory usage and the size of saved states.
  */
-export class Outline {
+export class Text {
   /**
    * The Order that manages this list's Positions and their metadata.
    * See [Managing Metadata](https://github.com/mweidner037/list-positions#managing-metadata).
    */
   readonly order: Order;
-  private readonly itemList: ItemList<number, SparseIndices>;
+  private readonly itemList: ItemList<string, SparseString>;
 
   /**
-   * Constructs an Outline, initially empty.
+   * Constructs a Text, initially empty.
    *
    * @param order The Order to use for `this.order`.
    * Multiple Lists/Outlines/Texts/LexLists can share an Order; they then automatically
    * share metadata. If not provided, a `new Order()` is used.
    *
-   * @see Outline.fromPositions To construct an Outline from an initial set of Positions.
+   * @see Text.fromEntries To construct a Text from an initial set of entries.
    */
   constructor(order?: Order) {
     this.order = order ?? new Order();
-    this.itemList = new ItemList(this.order, sparseIndicesFactory);
+    this.itemList = new ItemList(this.order, sparseStringFactory);
   }
 
   /**
-   * Returns a new Outline using the given Order and with the given set of Positions.
+   * Returns a new Text using the given Order and with the given
+   * ordered-map entries.
    *
    * Like when loading a saved state, you must deliver all of the Positions'
    * dependent metadata to `order` before calling this method.
    */
-  static fromPositions(positions: Iterable<Position>, order: Order): Outline {
-    const outline = new Outline(order);
-    for (const pos of positions) {
-      outline.add(pos);
+  static fromEntries(
+    entries: Iterable<[pos: Position, char: string]>,
+    order: Order
+  ): Text {
+    const text = new Text(order);
+    for (const [pos, char] of entries) {
+      checkChar(char);
+      text.set(pos, char);
     }
-    return outline;
+    return text;
   }
 
   /**
-   * Returns a new Outline using the given Order and with the given
-   * items (as defined by Outline.items).
+   * Returns a new Text using the given Order and with the given
+   * items (as defined by Text.items).
    *
    * Like when loading a saved state, you must deliver all of the Positions'
    * dependent metadata to `order` before calling this method.
    */
   static fromItems(
-    items: Iterable<[startPos: Position, count: number]>,
+    items: Iterable<[startPos: Position, chars: string]>,
     order: Order
-  ): Outline {
-    const outline = new Outline(order);
-    for (const [startPos, count] of items) {
-      outline.add(startPos, count);
+  ): Text {
+    const text = new Text(order);
+    for (const [startPos, chars] of items) {
+      text.set(startPos, chars);
     }
-    return outline;
+    return text;
   }
 
   // ----------
@@ -111,15 +123,15 @@ export class Outline {
   // ----------
 
   /**
-   * Adds the given Position.
+   * Sets the char at the given position.
    *
-   * If the position is already present, nothing happens.
-   * Otherwise, later positions in the list shift right
+   * If the position is already present, its char is overwritten.
+   * Otherwise, later chars in the list shift right
    * (increment their index).
    */
-  add(pos: Position): void;
+  set(pos: Position, char: string): void;
   /**
-   * Adds a sequence of Positions within the same [bunch](https://github.com/mweidner037/list-positions#bunches).
+   * Sets the chars at a sequence of Positions within the same [bunch](https://github.com/mweidner037/list-positions#bunches).
    *
    * The Positions start at `startPos` and have the same `bunchID` but increasing `innerIndex`.
    * Note that these Positions might not be contiguous anymore, if later
@@ -127,15 +139,26 @@ export class Outline {
    *
    * @see Order.startPosToArray
    */
-  add(startPos: Position, sameBunchCount?: number): void;
-  add(startPos: Position, count = 1): void {
-    this.itemList.set(startPos, count);
+  set(startPos: Position, chars: string): void;
+  set(startPos: Position, chars: string): void {
+    this.itemList.set(startPos, chars);
   }
 
   /**
-   * Deletes the given position, making it no longer present in the list.
+   * Sets the char at the given index (equivalently, at Position `this.positionAt(index)`),
+   * overwriting the existing char.
    *
-   * If the position was indeed present, later positions in the list shift left (decrement their index).
+   * @throws If index is not in `[0, this.length)`.
+   */
+  setAt(index: number, char: string): void {
+    checkChar(char);
+    this.set(this.positionAt(index), char);
+  }
+
+  /**
+   * Deletes the given position, making it and its char no longer present in the list.
+   *
+   * If the position was indeed present, later chars in the list shift left (decrement their index).
    */
   delete(pos: Position): void;
   /**
@@ -153,7 +176,7 @@ export class Outline {
   }
 
   /**
-   * Deletes `count` positions starting at `index`.
+   * Deletes `count` chars starting at `index`.
    *
    * @throws If any of `index`, ..., `index + count - 1` are not in `[0, this.length)`.
    */
@@ -166,7 +189,7 @@ export class Outline {
   }
 
   /**
-   * Deletes every Position in the list, making it empty.
+   * Deletes every char in the list, making it empty.
    *
    * `this.order` is unaffected (retains all metadata).
    */
@@ -175,20 +198,23 @@ export class Outline {
   }
 
   /**
-   * Inserts a new Position just after prevPos.
+   * Inserts the given char just after prevPos, at a new Position.
 
-   * Later positions in the list shift right
+   * Later chars in the list shift right
    * (increment their index).
    * 
    * In a collaborative setting, the new Position is *globally unique*, even
-   * if other users call `Outline.insert` (or similar methods) concurrently.
+   * if other users call `List.insert` (or similar methods) concurrently.
    * 
    * @returns [insertion Position, [created bunch's](https://github.com/mweidner037/list-positions#createdBunch) BunchMeta (or null)].
    * @throws If prevPos is Order.MAX_POSITION.
    */
-  insert(prevPos: Position): [pos: Position, createdBunch: BunchMeta | null];
+  insert(
+    prevPos: Position,
+    char: string
+  ): [pos: Position, createdBunch: BunchMeta | null];
   /**
-   * Inserts `count` new Positions just after prevPos.
+   * Inserts the given chars just after prevPos, at a series of new Positions.
    *
    * The new Positions all use the same [bunch](https://github.com/mweidner037/list-positions#bunches), with sequential
    * `innerIndex` (starting at the returned startPos).
@@ -197,35 +223,38 @@ export class Outline {
    *
    * @returns [starting Position, [created bunch's](https://github.com/mweidner037/list-positions#createdBunch) BunchMeta (or null)].
    * @throws If prevPos is Order.MAX_POSITION.
-   * @throws If no values are provided.
-   * @see Order.startPosToArray To convert (startPos, count) to an array of Positions.
+   * @throws If no chars are provided.
+   * @see Order.startPosToArray To convert (startPos, chars.length) to an array of Positions.
    */
   insert(
     prevPos: Position,
-    count?: number
+    chars: string
   ): [startPos: Position, createdBunch: BunchMeta | null];
   insert(
     prevPos: Position,
-    count = 1
+    chars: string
   ): [startPos: Position, createdBunch: BunchMeta | null] {
-    return this.itemList.insert(prevPos, count);
+    return this.itemList.insert(prevPos, chars);
   }
 
   /**
-   * Inserts a new Position at `index` (i.e., between the positions at `index - 1` and `index`).
+   * Inserts the given char at `index` (i.e., between the chars at `index - 1` and `index`), at a new Position.
    *
-   * Later positions in the list shift right
+   * Later chars in the list shift right
    * (increment their index).
    *
    * In a collaborative setting, the new Position is *globally unique*, even
-   * if other users call `Outline.insertAt` (or similar methods) concurrently.
+   * if other users call `List.insertAt` (or similar methods) concurrently.
    *
    * @returns [insertion Position, [created bunch's](https://github.com/mweidner037/list-positions#createdBunch) BunchMeta (or null)].
    * @throws If index is not in `[0, this.length]`. The index `this.length` is allowed and will cause an append, unless this list's current last Position is Order.MAX_POSITION.
    */
-  insertAt(index: number): [pos: Position, createdBunch: BunchMeta | null];
+  insertAt(
+    index: number,
+    char: string
+  ): [pos: Position, createdBunch: BunchMeta | null];
   /**
-   * Inserts `count` new Positions at `index` (i.e., between the values at `index - 1` and `index`).
+   * Inserts the given chars at `index` (i.e., between the chars at `index - 1` and `index`), at a series of new Positions.
    *
    * The new Positions all use the same [bunch](https://github.com/mweidner037/list-positions#bunches), with sequential
    * `innerIndex` (starting at the returned startPos).
@@ -234,23 +263,43 @@ export class Outline {
    *
    * @returns [starting Position, [created bunch's](https://github.com/mweidner037/list-positions#createdBunch) BunchMeta (or null)].
    * @throws If index is not in `[0, this.length]`. The index `this.length` is allowed and will cause an append, unless this list's current last Position is Order.MAX_POSITION.
-   * @throws If count is 0.
-   * @see Order.startPosToArray To convert (startPos, count) to an array of Positions.
+   * @throws If no chars are provided.
+   * @see Order.startPosToArray To convert (startPos, chars.length) to an array of Positions.
    */
   insertAt(
     index: number,
-    count?: number
+    chars: string
   ): [startPos: Position, createdBunch: BunchMeta | null];
   insertAt(
     index: number,
-    count = 1
+    chars: string
   ): [startPos: Position, createdBunch: BunchMeta | null] {
-    return this.itemList.insertAt(index, count);
+    return this.itemList.insertAt(index, chars);
   }
 
   // ----------
   // Accessors
   // ----------
+
+  /**
+   * Returns the char at the given position, or undefined if it is not currently present.
+   */
+  get(pos: Position): string | undefined {
+    const located = this.itemList.getItem(pos);
+    if (located === null) return undefined;
+    const [item, offset] = located;
+    return item[offset];
+  }
+
+  /**
+   * Returns the char currently at index.
+   *
+   * @throws If index is not in `[0, this.length)`.
+   */
+  getAt(index: number): string {
+    const [item, offset] = this.itemList.getItemAt(index);
+    return item[offset];
+  }
 
   /**
    * Returns whether the given position is currently present in the list.
@@ -266,10 +315,10 @@ export class Outline {
    * then the result depends on searchDir:
    * - "none" (default): Returns -1.
    * - "left": Returns the next index to the left of pos.
-   * If there are no values to the left of pos,
+   * If there are no chars to the left of pos,
    * returns -1.
    * - "right": Returns the next index to the right of pos.
-   * If there are no values to the right of pos,
+   * If there are no chars to the right of pos,
    * returns `this.length`.
    *
    * To find the index where a position would be if
@@ -324,11 +373,42 @@ export class Outline {
   // Iterators
   // ----------
 
+  /** Returns an iterator for chars in the list, in list order. */
+  [Symbol.iterator](): IterableIterator<string> {
+    return this.values();
+  }
+
   /**
-   * Returns an iterator for present positions, in list order.
+   * Returns an iterator for chars in the list, in list order.
+   *
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
-  [Symbol.iterator](): IterableIterator<Position> {
-    return this.positions();
+  *values(start?: number, end?: number): IterableIterator<string> {
+    for (const [, item] of this.itemList.items(start, end)) yield* item;
+  }
+
+  /**
+   * Returns a copy of a section of this list, as a string.
+   *
+   * Arguments are as in [Array.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice).
+   */
+  slice(start?: number, end?: number): string {
+    [start, end] = normalizeSliceRange(this.length, start, end);
+    let ans = "";
+    for (const [, chars] of this.itemList.items(start, end)) {
+      ans += chars;
+    }
+    return ans;
+  }
+
+  /**
+   * Returns the current text as a literal string.
+   */
+  toString(): string {
+    return this.slice();
   }
 
   /**
@@ -340,12 +420,27 @@ export class Outline {
    * @throws If `start < 0`, `end > this.length`, or `start > end`.
    */
   *positions(start?: number, end?: number): IterableIterator<Position> {
+    for (const [pos] of this.entries(start, end)) yield pos;
+  }
+
+  /**
+   * Returns an iterator for [pos, char] pairs in the list, in list order. These are its entries as an ordered map.
+   *
+   * Optionally, you may specify a range of indices `[start, end)` instead of
+   * iterating the entire list.
+   *
+   * @throws If `start < 0`, `end > this.length`, or `start > end`.
+   */
+  *entries(
+    start?: number,
+    end?: number
+  ): IterableIterator<[pos: Position, char: string]> {
     for (const [
       { bunchID, innerIndex: startInnerIndex },
       item,
     ] of this.itemList.items(start, end)) {
-      for (let i = 0; i < item; i++) {
-        yield { bunchID, innerIndex: startInnerIndex + i };
+      for (let i = 0; i < item.length; i++) {
+        yield [{ bunchID, innerIndex: startInnerIndex + i }, item[i]];
       }
     }
   }
@@ -355,11 +450,11 @@ export class Outline {
    *
    * Each *item* is a series of entries that have contiguous positions
    * from the same [bunch](https://github.com/mweidner037/list-positions#bunches).
-   * Specifically, for an item [startPos, count], the positions start at `startPos`
+   * Specifically, for an item [startPos, chars], the positions start at `startPos`
    * and have the same `bunchID` but increasing `innerIndex`.
    *
    * You can use this method as an optimized version of other iterators, or as
-   * an alternative in-order save format (see Outline.fromItems).
+   * an alternative in-order save format (see List.fromItems).
    *
    * Optionally, you may specify a range of indices `[start, end)` instead of
    * iterating the entire list.
@@ -369,7 +464,7 @@ export class Outline {
   items(
     start?: number,
     end?: number
-  ): IterableIterator<[startPos: Position, count: number]> {
+  ): IterableIterator<[startPos: Position, chars: string]> {
     return this.itemList.items(start, end);
   }
 
@@ -388,29 +483,28 @@ export class Outline {
   // ----------
 
   /**
-   * Returns a saved state for this Outline.
+   * Returns a saved state for this List.
    *
-   * The saved state describes our current set of Positions in JSON-serializable form.
-   * You can load this state on another Outline by calling `load(savedState)`,
+   * The saved state describes our current (Position -> char) map in JSON-serializable form.
+   * You can load this state on another List by calling `load(savedState)`,
    * possibly in a different session or on a different device.
    */
-  save(): OutlineSavedState {
+  save(): TextSavedState {
     return this.itemList.save();
   }
 
   /**
-   * Loads a saved state returned by another Outline's `save()` method.
+   * Loads a saved state returned by another List's `save()` method.
    *
-   * Loading sets our set of Positions to match the saved Outline's, *overwriting*
+   * Loading sets our (Position -> char) map to match the saved List's, *overwriting*
    * our current state.
    *
    * **Before loading a saved state, you must deliver its dependent metadata
    * to this.Order**. For example, you could save and load the Order's state
-   * alongside the Outline's state, making sure to load the Order first.
-   * See [Managing Metadata](https://github.com/mweidner037/list-positions#save-load) for an example
-   * with List (Outline is analogous).
+   * alongside the List's state, making sure to load the Order first.
+   * See [Managing Metadata](https://github.com/mweidner037/list-positions#save-load) for an example.
    */
-  load(savedState: OutlineSavedState): void {
+  load(savedState: TextSavedState): void {
     this.itemList.load(savedState);
   }
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,5 +1,5 @@
 import { SparseString } from "sparse-array-rled";
-import { BunchMeta, BunchNode } from "./bunch";
+import { BunchMeta } from "./bunch";
 import { ItemList, SparseItemsFactory } from "./internal/item_list";
 import { normalizeSliceRange } from "./internal/util";
 import { Order } from "./order";
@@ -55,9 +55,12 @@ export type TextSavedState = {
  *
  * See [List, Position, and Order](https://github.com/mweidner037/list-positions#list-position-and-order) in the readme.
  *
- * Text is functionally equivalent to a `List<string>` with single-char values,
+ * Text is functionally equivalent to `List<string>` with single-char values,
  * but it uses strings internally and in bulk methods, instead of arrays
  * of single chars. This reduces memory usage and the size of saved states.
+ *
+ * Technically, Text is a sequence of UTF-16 code units, like an ordinary JavaScript
+ * string ([MDN reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#utf-16_characters_unicode_code_points_and_grapheme_clusters)).
  */
 export class Text {
   /**
@@ -466,16 +469,6 @@ export class Text {
     end?: number
   ): IterableIterator<[startPos: Position, chars: string]> {
     return this.itemList.items(start, end);
-  }
-
-  /**
-   * Returns an iterator for all dependencies for this list.
-   *
-   * These are all BunchNodes that have nontrivial values plus their ancestors,
-   * excluding the root.
-   */
-  dependentNodes(): IterableIterator<BunchNode> {
-    return this.itemList.dependentNodes();
   }
 
   // ----------

--- a/test/lists/fuzz.test.ts
+++ b/test/lists/fuzz.test.ts
@@ -24,6 +24,7 @@ describe("lists - fuzz", () => {
             Math.floor(rng() * (checker.list.length + 1)),
             Math.floor(rng() * 10000)
           );
+          // eslint-disable-next-line no-dupe-else-if
         } else if (rng() < 0.5) {
           // 1/4: setAt
           checker.setAt(
@@ -44,10 +45,11 @@ describe("lists - fuzz", () => {
           // 1/2: insertAt bulk
           checker.insertAt(
             Math.floor(rng() * (checker.list.length + 1)),
-            ...new Array(1 + Math.floor(rng() * 10)).fill(
+            ...new Array<number>(1 + Math.floor(rng() * 10)).fill(
               Math.floor(rng() * 10000)
             )
           );
+          // eslint-disable-next-line no-dupe-else-if
         } else if (rng() < 0.5) {
           // 1/4: setAt
           checker.setAt(

--- a/test/lists/manual.test.ts
+++ b/test/lists/manual.test.ts
@@ -72,7 +72,7 @@ describe("lists - manual", () => {
       test("replace partial", () => {
         // Test parentValuesBefore update logic by doing a set whose
         // replaced values are neither full nor empty, with interspersed children.
-        checker.insertAt(0, ...new Array(20).fill(31));
+        checker.insertAt(0, ...new Array<number>(20).fill(31));
         const positions = [...checker.list.positions()];
 
         // Interspersed children.
@@ -86,7 +86,7 @@ describe("lists - manual", () => {
         }
 
         // Overwrite partially-filled positions.
-        checker.set(positions[4], ...new Array(10).fill(25));
+        checker.set(positions[4], ...new Array<number>(10).fill(25));
       });
     });
 
@@ -100,7 +100,7 @@ describe("lists - manual", () => {
       test("replace partial", () => {
         // Test parentValuesBefore update logic by doing a delete whose
         // replaced values are neither full nor empty, with interspersed children.
-        checker.insertAt(0, ...new Array(20).fill(31));
+        checker.insertAt(0, ...new Array<number>(20).fill(31));
         const positions = [...checker.list.positions()];
 
         // Interspersed children.

--- a/test/lists/util.ts
+++ b/test/lists/util.ts
@@ -46,7 +46,7 @@ export class Checker {
       const pos = this.order.unlex(iter.key!);
       assert.strictEqual(this.list.getAt(i), iter.value!);
       assert.deepStrictEqual(this.list.positionAt(i), pos);
-      assert.strictEqual(this.list.get(pos), iter.value!);
+      assert.strictEqual(this.list.get(pos), iter.value);
       assert.strictEqual(this.list.indexOfPosition(pos), i);
       assert.deepStrictEqual(this.outline.positionAt(i), pos);
       assert.strictEqual(this.outline.indexOfPosition(pos), i);

--- a/test/order/manual.test.ts
+++ b/test/order/manual.test.ts
@@ -328,8 +328,8 @@ function testTwoUsers(replicaID1: string, replicaID2: string) {
     if (alice.compare(d, c) < 0) [c, d] = [d, c];
 
     // Try making e on both alice and bob.
-    let [e1] = alice.createPositions(c, d, 1);
-    let [e2] = bob.createPositions(c, d, 1);
+    const [e1] = alice.createPositions(c, d, 1);
+    const [e2] = bob.createPositions(c, d, 1);
 
     assert.notDeepEqual(e1, e2);
     assertIsOrdered([a, c, e1, d, b], alice);


### PR DESCRIPTION
API changes to permit additional optimizations (e.g., iterators that visit "items" in bulk).

Breaking changes:
- Iterators that input `start` and `end` arguments no longer behave like `Array.slice`, except for methods actually named `slice`. Instead, `start` defaults to 0, `end` defaults to the length, and out-of-bounds or reversed inputs throw an error.
- `List.from` -> `List.fromEntries`, `LexList.from` -> `LexList.fromEntries`, `Outline.from` -> `Outline.fromPositions`.

New features:
- `Text` class: an alternative to a `List` of single-char values that uses strings instead of arrays of single chars internally, for reduced space usage (see `benchmark_results.md`).
- `items()` iterators on `List` and `Outline`, for more efficient iteration.
- ~`List.dependentNodes()` method (etc.), for tombstone-free saving, similar to a `LexListSavedState` but in `Position` style.~

Misc:
- Minor docs improvements.
- Optimized implementation of `slice()` methods.