### PR TITLE
Cursor bind option

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,7 @@ A _cursor_ points to a spot in the list between two values - e.g., a cursor in a
 
 Internally, a cursor is represented as the Position (or AbsPosition, for AbsList) of the value to its left, or `MIN_POSITION` if it is at the start of the list. If that position becomes not-present in the list, the cursor's literal value remains the same, but its current index shifts to the left. (To bind to the Position on the right instead, pass `bind = "right"` to the cursor methods.)
 
-Convert indices to cursors and back using methods `cursorAt` and `indexOfCursor`, on classes List, Text, Outline, and AbsList. These are wrappers around `positionAt` and `indexOfPosition` that get the edge cases right.
+Convert indices to cursors and back using methods `cursorAt` and `indexOfCursor`, on classes List, Text, Outline, and AbsList. These are wrappers around `positionAt` and `indexOfPosition` that get the edge cases correct.
 
 #### Lexicographic Strings
 

--- a/README.md
+++ b/README.md
@@ -420,9 +420,9 @@ For AbsPositions, use `AbsPositions.MIN_POSITION` and `AbsPositions.MAX_POSITION
 
 A _cursor_ points to a spot in the list between two values - e.g., a cursor in a text document.
 
-Internally, a cursor is represented as the Position (or AbsPosition, for AbsList) of the value to its left, or `MIN_POSITION` if it is at the start of the list. If that position becomes not-present in the list, the cursor's literal value remains the same, but its current index shifts to the left.
+Internally, a cursor is represented as the Position (or AbsPosition, for AbsList) of the value to its left, or `MIN_POSITION` if it is at the start of the list. If that position becomes not-present in the list, the cursor's literal value remains the same, but its current index shifts to the left. (To bind to the Position on the right instead, pass `bind = "right"` to the cursor methods.)
 
-Convert indices to cursors and back using methods `cursorAt` and `indexOfCursor`, on classes List, Text, Outline, and AbsList. (These are wrappers around `positionAt` and `indexOfPosition` that get the edge cases right.)
+Convert indices to cursors and back using methods `cursorAt` and `indexOfCursor`, on classes List, Text, Outline, and AbsList. These are wrappers around `positionAt` and `indexOfPosition` that get the edge cases right.
 
 #### Lexicographic Strings
 

--- a/src/abs_list.ts
+++ b/src/abs_list.ts
@@ -322,16 +322,18 @@ export class AbsList<T> {
   }
 
   /**
-   * Returns the cursor at `index` within the list, i.e., between the positions at `index - 1` and `index`.
+   * Returns the cursor at `index` within the list, i.e., in the gap between the positions at `index - 1` and `index`.
    * See [Cursors](https://github.com/mweidner037/list-positions#cursors).
    *
    * Invert with {@link indexOfCursor}, possibly on a different AbsList/List/Text/Outline or a different device.
    * (For non-AbsLists, you will need to convert it to a Position using {@link Order.unabs}.)
    *
+   * @param bind Whether to bind to the left or the right side of the gap, in case positions
+   * later appear between `index - 1` and `index`. Default: `"left"`, which is typical for text cursors.
    * @throws If index is not in the range `[0, list.length]`.
    */
-  cursorAt(index: number): AbsPosition {
-    return index === 0 ? AbsPositions.MIN_POSITION : this.positionAt(index - 1);
+  cursorAt(index: number, bind?: "left" | "right"): AbsPosition {
+    return this.order.abs(this.list.cursorAt(index, bind));
   }
 
   /**
@@ -339,11 +341,11 @@ export class AbsList<T> {
    * That is, the cursor is between the list elements at `index - 1` and `index`.
    *
    * Inverts {@link cursorAt}.
+   *
+   * @param bind The `bind` value that was used with {@link cursorAt}, if any.
    */
-  indexOfCursor(cursor: AbsPosition): number {
-    return AbsPositions.positionEquals(cursor, AbsPositions.MIN_POSITION)
-      ? 0
-      : this.indexOfPosition(cursor, "left") + 1;
+  indexOfCursor(cursor: AbsPosition, bind?: "left" | "right"): number {
+    return this.list.indexOfCursor(this.order.unabs(cursor), bind);
   }
 
   // ----------

--- a/src/internal/item_list.ts
+++ b/src/internal/item_list.ts
@@ -452,6 +452,42 @@ export class ItemList<I, S extends SparseItems<I>> {
     return this.state.get(node)?.total ?? 0;
   }
 
+  /**
+   * Returns the cursor at `index` within the list, i.e., in the gap between the positions at `index - 1` and `index`.
+   * See [Cursors](https://github.com/mweidner037/list-positions#cursors).
+   *
+   * Invert with {@link indexOfCursor}, possibly on a different List/Text/Outline/AbsList or a different device.
+   *
+   * @param bind Whether to bind to the left or the right side of the gap, in case positions
+   * later appear between `index - 1` and `index`. Default: `"left"`, which is typical for text cursors.
+   * @throws If index is not in the range `[0, list.length]`.
+   */
+  cursorAt(index: number, bind: "left" | "right" = "left"): Position {
+    if (bind === "left") {
+      return index === 0 ? MIN_POSITION : this.positionAt(index - 1);
+    } else {
+      return index === this.length ? MAX_POSITION : this.positionAt(index);
+    }
+  }
+
+  /**
+   * Returns the current index of `cursor` within the list.
+   * That is, the cursor is between the list elements at `index - 1` and `index`.
+   *
+   * Inverts {@link cursorAt}.
+   * 
+   * @param bind The `bind` value that was used with {@link cursorAt}.
+   */
+  indexOfCursor(cursor: Position, bind: "left" | "right" = "right"): number {
+    if (bind === "left") {
+      // If cursor is MIN_POSITION, this is -1 + 1 = 0.
+      return this.indexOfPosition(cursor, "left") + 1;
+    } else {
+      // If cursor is MAX_POSITION, this is length.
+      return this.indexOfPosition(cursor, "right");
+    }
+  }
+
   // ----------
   // Iterators
   // ----------

--- a/src/internal/item_list.ts
+++ b/src/internal/item_list.ts
@@ -475,7 +475,7 @@ export class ItemList<I, S extends SparseItems<I>> {
    * That is, the cursor is between the list elements at `index - 1` and `index`.
    *
    * Inverts {@link cursorAt}.
-   * 
+   *
    * @param bind The `bind` value that was used with {@link cursorAt}, if any.
    */
   indexOfCursor(cursor: Position, bind: "left" | "right" = "left"): number {

--- a/src/internal/item_list.ts
+++ b/src/internal/item_list.ts
@@ -476,9 +476,9 @@ export class ItemList<I, S extends SparseItems<I>> {
    *
    * Inverts {@link cursorAt}.
    * 
-   * @param bind The `bind` value that was used with {@link cursorAt}.
+   * @param bind The `bind` value that was used with {@link cursorAt}, if any.
    */
-  indexOfCursor(cursor: Position, bind: "left" | "right" = "right"): number {
+  indexOfCursor(cursor: Position, bind: "left" | "right" = "left"): number {
     if (bind === "left") {
       // If cursor is MIN_POSITION, this is -1 + 1 = 0.
       return this.indexOfPosition(cursor, "left") + 1;

--- a/src/list.ts
+++ b/src/list.ts
@@ -3,7 +3,7 @@ import { BunchMeta } from "./bunch";
 import { ItemList, SparseItemsFactory } from "./internal/item_list";
 import { normalizeSliceRange } from "./internal/util";
 import { Order } from "./order";
-import { MIN_POSITION, Position, positionEquals } from "./position";
+import { Position } from "./position";
 
 const sparseArrayFactory: SparseItemsFactory<
   unknown[],
@@ -355,15 +355,17 @@ export class List<T> {
   }
 
   /**
-   * Returns the cursor at `index` within the list, i.e., between the positions at `index - 1` and `index`.
+   * Returns the cursor at `index` within the list, i.e., in the gap between the positions at `index - 1` and `index`.
    * See [Cursors](https://github.com/mweidner037/list-positions#cursors).
    *
    * Invert with {@link indexOfCursor}, possibly on a different List/Text/Outline/AbsList or a different device.
    *
+   * @param bind Whether to bind to the left or the right side of the gap, in case positions
+   * later appear between `index - 1` and `index`. Default: `"left"`, which is typical for text cursors.
    * @throws If index is not in the range `[0, list.length]`.
    */
-  cursorAt(index: number): Position {
-    return index === 0 ? MIN_POSITION : this.positionAt(index - 1);
+  cursorAt(index: number, bind?: "left" | "right"): Position {
+    return this.itemList.cursorAt(index, bind);
   }
 
   /**
@@ -371,11 +373,11 @@ export class List<T> {
    * That is, the cursor is between the list elements at `index - 1` and `index`.
    *
    * Inverts {@link cursorAt}.
+   *
+   * @param bind The `bind` value that was used with {@link cursorAt}, if any.
    */
-  indexOfCursor(cursor: Position): number {
-    return positionEquals(cursor, MIN_POSITION)
-      ? 0
-      : this.indexOfPosition(cursor, "left") + 1;
+  indexOfCursor(cursor: Position, bind?: "left" | "right"): number {
+    return this.itemList.indexOfCursor(cursor, bind);
   }
 
   // ----------

--- a/src/outline.ts
+++ b/src/outline.ts
@@ -2,7 +2,7 @@ import { SparseIndices } from "sparse-array-rled";
 import { BunchMeta } from "./bunch";
 import { ItemList, SparseItemsFactory } from "./internal/item_list";
 import { Order } from "./order";
-import { MIN_POSITION, Position, positionEquals } from "./position";
+import { Position } from "./position";
 
 const sparseIndicesFactory: SparseItemsFactory<number, SparseIndices> = {
   // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -308,15 +308,17 @@ export class Outline {
   }
 
   /**
-   * Returns the cursor at `index` within the list, i.e., between the positions at `index - 1` and `index`.
+   * Returns the cursor at `index` within the list, i.e., in the gap between the positions at `index - 1` and `index`.
    * See [Cursors](https://github.com/mweidner037/list-positions#cursors).
    *
    * Invert with {@link indexOfCursor}, possibly on a different List/Text/Outline/AbsList or a different device.
    *
+   * @param bind Whether to bind to the left or the right side of the gap, in case positions
+   * later appear between `index - 1` and `index`. Default: `"left"`, which is typical for text cursors.
    * @throws If index is not in the range `[0, list.length]`.
    */
-  cursorAt(index: number): Position {
-    return index === 0 ? MIN_POSITION : this.positionAt(index - 1);
+  cursorAt(index: number, bind?: "left" | "right"): Position {
+    return this.itemList.cursorAt(index, bind);
   }
 
   /**
@@ -324,11 +326,11 @@ export class Outline {
    * That is, the cursor is between the list elements at `index - 1` and `index`.
    *
    * Inverts {@link cursorAt}.
+   *
+   * @param bind The `bind` value that was used with {@link cursorAt}, if any.
    */
-  indexOfCursor(cursor: Position): number {
-    return positionEquals(cursor, MIN_POSITION)
-      ? 0
-      : this.indexOfPosition(cursor, "left") + 1;
+  indexOfCursor(cursor: Position, bind?: "left" | "right"): number {
+    return this.itemList.indexOfCursor(cursor, bind);
   }
 
   // ----------

--- a/src/text.ts
+++ b/src/text.ts
@@ -3,7 +3,7 @@ import { BunchMeta } from "./bunch";
 import { ItemList, SparseItemsFactory } from "./internal/item_list";
 import { normalizeSliceRange } from "./internal/util";
 import { Order } from "./order";
-import { MIN_POSITION, Position, positionEquals } from "./position";
+import { Position } from "./position";
 
 const sparseStringFactory: SparseItemsFactory<string, SparseString> = {
   // eslint-disable-next-line @typescript-eslint/unbound-method
@@ -361,15 +361,17 @@ export class Text {
   }
 
   /**
-   * Returns the cursor at `index` within the list, i.e., between the positions at `index - 1` and `index`.
+   * Returns the cursor at `index` within the list, i.e., in the gap between the positions at `index - 1` and `index`.
    * See [Cursors](https://github.com/mweidner037/list-positions#cursors).
    *
    * Invert with {@link indexOfCursor}, possibly on a different List/Text/Outline/AbsList or a different device.
    *
+   * @param bind Whether to bind to the left or the right side of the gap, in case positions
+   * later appear between `index - 1` and `index`. Default: `"left"`, which is typical for text cursors.
    * @throws If index is not in the range `[0, list.length]`.
    */
-  cursorAt(index: number): Position {
-    return index === 0 ? MIN_POSITION : this.positionAt(index - 1);
+  cursorAt(index: number, bind?: "left" | "right"): Position {
+    return this.itemList.cursorAt(index, bind);
   }
 
   /**
@@ -377,11 +379,11 @@ export class Text {
    * That is, the cursor is between the list elements at `index - 1` and `index`.
    *
    * Inverts {@link cursorAt}.
+   *
+   * @param bind The `bind` value that was used with {@link cursorAt}, if any.
    */
-  indexOfCursor(cursor: Position): number {
-    return positionEquals(cursor, MIN_POSITION)
-      ? 0
-      : this.indexOfPosition(cursor, "left") + 1;
+  indexOfCursor(cursor: Position, bind?: "left" | "right"): number {
+    return this.itemList.indexOfCursor(cursor, bind);
   }
 
   // ----------

--- a/test/lists/manual.test.ts
+++ b/test/lists/manual.test.ts
@@ -61,7 +61,7 @@ describe("lists - manual", () => {
       list.insertAt(0, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
     });
 
-    function bindIndependent(bind: "left" | "right") {
+    function bindIndependent(bind: "left" | "right" | undefined) {
       test("errors", () => {
         assert.throws(() => list.cursorAt(-1, bind));
         assert.throws(() => list.cursorAt(list.length + 1, bind));
@@ -124,6 +124,7 @@ describe("lists - manual", () => {
       test("insert in gap", () => {
         const midCursor = list.cursorAt(5, "left");
 
+        // Gap at cursor: bind dependent.
         list.insertAt(5, 100);
         assert.strictEqual(list.indexOfCursor(midCursor, "left"), 5);
 
@@ -143,7 +144,7 @@ describe("lists - manual", () => {
         list.insertAt(0, 101);
         assert.strictEqual(list.indexOfCursor(cursor, "left"), 0);
 
-        list.deleteAt(0);
+        list.deleteAt(0, 2);
         assert.strictEqual(list.indexOfCursor(cursor, "left"), 0);
 
         list.clear();
@@ -157,6 +158,7 @@ describe("lists - manual", () => {
       test("insert in gap", () => {
         const midCursor = list.cursorAt(5, "right");
 
+        // Gap at cursor: bind dependent.
         list.insertAt(5, 100);
         assert.strictEqual(list.indexOfCursor(midCursor, "right"), 6);
 
@@ -176,11 +178,19 @@ describe("lists - manual", () => {
         list.insertAt(list.length, 101);
         assert.strictEqual(list.indexOfCursor(cursor, "right"), list.length);
 
-        list.deleteAt(list.length - 1);
+        list.deleteAt(list.length - 2, 2);
         assert.strictEqual(list.indexOfCursor(cursor, "right"), list.length);
 
         list.clear();
         assert.strictEqual(list.indexOfCursor(cursor, "right"), list.length);
+      });
+    });
+
+    describe("bind default", () => {
+      bindIndependent(undefined);
+
+      test("is left", () => {
+        assert.deepStrictEqual(list.cursorAt(5), list.cursorAt(5, "left"));
       });
     });
   });


### PR DESCRIPTION
Add option for cursors to bind "left" (default, current behavior) or "right".

This chance makes cursors as flexible as list-formattings's Anchors, but with the binding stored independently, instead of built-in like Anchors' `before` prop.